### PR TITLE
Pdf fix

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobb.java
@@ -34,7 +34,7 @@ public class JournalpostJobb {
     @Autowired
     private StsService stsService;
 
-    static final String MAPPING_FEIL = "DATA_FEIL";
+    static final String MAPPING_FEIL = "FEILET";
 
     @Scheduled(cron = "${prosess.cron}")
     public void avtalerTilJournalfoering() {
@@ -84,7 +84,7 @@ public class JournalpostJobb {
             log.error("FEIL Journalførte avtaler ble ikke lagret Tiltaksgjennomføring databasen! Avtaler som ble journalført (avtale-id :: journalpost-id): {}", avtalerJournalfortInfo(journalfoeringer), e);
             deaktiverJobb();
         }
-        log.info("Ferdig journalført {} avtaler: {}", journalfoeringer.size(), avtalerJournalfortInfo(journalfoeringer));
+        log.info("Ferdig journalført {} avtaler: {}", journalfoeringer.keySet().stream().filter(key -> !journalfoeringer.get(key).equals(MAPPING_FEIL)).count(), avtalerJournalfortInfo(journalfoeringer));
     }
 
     private void deaktiverJobb() {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobb.java
@@ -2,18 +2,17 @@ package no.nav.tag.tiltaksgjennomforingprosess;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.tag.tiltaksgjennomforingprosess.domene.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforingprosess.domene.journalpost.Journalpost;
 import no.nav.tag.tiltaksgjennomforingprosess.factory.JournalpostFactory;
 import no.nav.tag.tiltaksgjennomforingprosess.integrasjon.JoarkService;
-import no.nav.tag.tiltaksgjennomforingprosess.integrasjon.TiltaksgjennomfoeringApiService;
 import no.nav.tag.tiltaksgjennomforingprosess.integrasjon.StsService;
+import no.nav.tag.tiltaksgjennomforingprosess.integrasjon.TiltaksgjennomfoeringApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -35,10 +34,12 @@ public class JournalpostJobb {
     @Autowired
     private StsService stsService;
 
+    static final String MAPPING_FEIL = "DATA_FEIL";
+
     @Scheduled(cron = "${prosess.cron}")
     public void avtalerTilJournalfoering() {
 
-        if(!enabled){
+        if (!enabled) {
             log.warn("Prosessen ble skrudd av pga. en feil. Sjekk tidligere feilmelding i loggen");
             return;
         }
@@ -46,7 +47,7 @@ public class JournalpostJobb {
         final String stsToken = stsService.hentToken();
         List<Avtale> avtalerTilJournalforing = tiltaksgjennomfoeringApiService.finnAvtalerTilJournalfoering(stsToken);
 
-        if(avtalerTilJournalforing.isEmpty()){
+        if (avtalerTilJournalforing.isEmpty()) {
             return;
         }
 
@@ -56,15 +57,23 @@ public class JournalpostJobb {
     }
 
     private Map<UUID, String> journalfoerAvtaler(String stsToken, List<Avtale> avtalerTilJournalforing) {
-        return avtalerTilJournalforing
-                .parallelStream()
-                .map(avtale -> {
-                    avtale.setJournalpostId(
-                            joarkService.sendJournalpost(stsToken, journalpostFactory.konverterTilJournalpost(avtale))
-                    );
-                    return avtale;
-                })
-                .collect(Collectors.toMap(Avtale::getId, Avtale::getJournalpostId));
+
+        Map<UUID, String> journalfoerteAvtaler = new HashMap<>(avtalerTilJournalforing.size());
+        avtalerTilJournalforing
+                .forEach(avtale -> {
+                    Optional<Journalpost> optJournalpost;
+                    try {
+                        optJournalpost = Optional.of(journalpostFactory.konverterTilJournalpost(avtale));
+                    } catch (Throwable t) {
+                        journalfoerteAvtaler.put(avtale.getId(), MAPPING_FEIL);
+                        optJournalpost = Optional.empty();
+                    }
+                    optJournalpost.ifPresent(journalpost -> {
+                        String journalpostId = joarkService.sendJournalpost(stsToken, journalpost);
+                        journalfoerteAvtaler.put(avtale.getId(), journalpostId);
+                    });
+                });
+        return journalfoerteAvtaler;
     }
 
     private void registrerAvtalerSomJournalfoert(final String stsToken, Map<UUID, String> journalfoeringer) {
@@ -83,7 +92,7 @@ public class JournalpostJobb {
         enabled = false;
     }
 
-    private List<String> avtalerJournalfortInfo(Map<UUID, String> journalfoeringer){
+    private List<String> avtalerJournalfortInfo(Map<UUID, String> journalfoeringer) {
         return journalfoeringer.keySet().stream().map(uuid -> uuid.toString() + " :: " + journalfoeringer.get(uuid)).collect(Collectors.toList());
     }
 }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobb.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobb.java
@@ -82,12 +82,12 @@ public class JournalpostJobb {
             tiltaksgjennomfoeringApiService.settAvtalerTilJournalfoert(stsToken, journalfoeringer);
         } catch (Exception e) {
             log.error("FEIL Journalførte avtaler ble ikke lagret Tiltaksgjennomføring databasen! Avtaler som ble journalført (avtale-id :: journalpost-id): {}", avtalerJournalfortInfo(journalfoeringer), e);
-            deaktiverJobb();
+            JournalpostJobb.deaktiverJobb();
         }
         log.info("Ferdig journalført {} avtaler: {}", journalfoeringer.keySet().stream().filter(key -> !journalfoeringer.get(key).equals(MAPPING_FEIL)).count(), avtalerJournalfortInfo(journalfoeringer));
     }
 
-    private void deaktiverJobb() {
+    private static void deaktiverJobb() {
         log.info("Deaktiverer jobb - hindrer ny journalføring av de samme avtalene");
         enabled = false;
     }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/factory/AvtaleTilPdf.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/factory/AvtaleTilPdf.java
@@ -151,20 +151,11 @@ class AvtaleTilPdf {
             for (Oppgave oppgave : avtale.getOppgaver()
             ) {
                 contentStream = skrivTekst(oppgave.getTittel(), contentStream, document, font_Bold, fontSize);
+                contentStream = skrivFritekstTilPdf(contentStream, oppgave.getBeskrivelse());
 
-                //TODO Fiks her
-                String oppgaveBesk = oppgave.getBeskrivelse();
-                contentStream = skrivTekst(oppgaveBesk, contentStream, document, font, fontSize);
-
-                //TODO Fiks her
                 contentStream.newLine();
                 contentStream = skrivTekst("Opplæring: ", contentStream, document, font_Bold, fontSize);
-
-
-                String opplaering = oppgave.getOpplaering();
-                contentStream = skrivTekst(opplaering, contentStream, document, font, fontSize);
-
-
+                contentStream = skrivFritekstTilPdf(contentStream, oppgave.getOpplaering());
                 contentStream.newLine();
                 aktulLinjerISiden += 2;
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/factory/AvtaleTilPdf.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/factory/AvtaleTilPdf.java
@@ -151,12 +151,20 @@ class AvtaleTilPdf {
             for (Oppgave oppgave : avtale.getOppgaver()
             ) {
                 contentStream = skrivTekst(oppgave.getTittel(), contentStream, document, font_Bold, fontSize);
+
+                //TODO Fiks her
                 String oppgaveBesk = oppgave.getBeskrivelse();
                 contentStream = skrivTekst(oppgaveBesk, contentStream, document, font, fontSize);
+
+                //TODO Fiks her
                 contentStream.newLine();
                 contentStream = skrivTekst("Opplæring: ", contentStream, document, font_Bold, fontSize);
+
+
                 String opplaering = oppgave.getOpplaering();
                 contentStream = skrivTekst(opplaering, contentStream, document, font, fontSize);
+
+
                 contentStream.newLine();
                 aktulLinjerISiden += 2;
             }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactory.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactory.java
@@ -7,9 +7,7 @@ import no.nav.tag.tiltaksgjennomforingprosess.domene.journalpost.Dokument;
 import no.nav.tag.tiltaksgjennomforingprosess.domene.journalpost.DokumentVariant;
 import no.nav.tag.tiltaksgjennomforingprosess.domene.journalpost.Journalpost;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.Arrays;
 import java.util.Base64;
@@ -33,7 +31,7 @@ public class JournalpostFactory {
         journalpost.setBruker(bruker);
         journalpost.setEksternReferanseId(EKSTREF_PREFIKS + avtale.getId().toString());
 
-        final byte[] dokumentPdfAsBytes = avtaleTilPdfBytes(avtale);
+        final byte[] dokumentPdfAsBytes = new AvtaleTilPdf().tilBytesAvPdf(avtale);
         final String dokumentXml = avtaleTilXml.genererXml(avtale);
 
         Dokument dokument = new Dokument();
@@ -43,15 +41,6 @@ public class JournalpostFactory {
         );
         journalpost.setDokumenter(Collections.singletonList(dokument));
         return journalpost;
-    }
-
-    private byte[] avtaleTilPdfBytes(Avtale avtale) {
-        try {
-            return new AvtaleTilPdf().tilBytesAvPdf(avtale);
-        } catch (Exception e) {
-            log.error("Feil ved generering til pdf fil: AvtaleId={}", avtale.getId(), e);
-            throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
     }
 
     private String encodeToBase64(final byte[] dokumentBytes) {

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/JoarkService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/JoarkService.java
@@ -8,10 +8,8 @@ import no.nav.tag.tiltaksgjennomforingprosess.properties.JournalpostProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -50,7 +48,7 @@ public class JoarkService {
             response = restTemplate.postForObject(uri, entity, JoarkResponse.class);
         } catch (Exception e) {
             log.error("Kall til Joark feilet: {}", response != null ? response.getMelding() : "", e);
-            throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Kall til Joark feilet: " + e.getMessage());
+            throw new RuntimeException("Kall til Joark feilet: " + e.getMessage());
         }
         log.info("Journalført avtale {}", journalpost.getEksternReferanseId());
         return response.getJournalpostId();

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/JoarkService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/JoarkService.java
@@ -46,11 +46,13 @@ public class JoarkService {
         HttpEntity<Journalpost> entity = new HttpEntity<>(journalpost, headers);
         JoarkResponse response = null;
         try {
+            log.info("Forsøker å journalføre avtale {}", journalpost.getEksternReferanseId());
             response = restTemplate.postForObject(uri, entity, JoarkResponse.class);
         } catch (Exception e) {
             log.error("Kall til Joark feilet: {}", response != null ? response.getMelding() : "", e);
             throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Kall til Joark feilet: " + e.getMessage());
         }
+        log.info("Journalført avtale {}", journalpost.getEksternReferanseId());
         return response.getJournalpostId();
     }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/StsService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/StsService.java
@@ -4,7 +4,6 @@ import no.nav.tag.tiltaksgjennomforingprosess.properties.StsProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -41,7 +40,7 @@ public class StsService {
         try {
             response = restTemplate.exchange(uri, HttpMethod.GET, entity, StsTokenResponse.class);
         } catch (Exception e) {
-            throw new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Kall til STS feilet: " + e.getMessage());
+            throw new RuntimeException("Kall til STS feilet: " + e.getMessage());
         }
         return response.getBody().getAccessToken();
     }

--- a/src/main/resources/config/application-dev.yaml
+++ b/src/main/resources/config/application-dev.yaml
@@ -6,7 +6,7 @@ spring:
     banner-mode: "console"
 
 prosess:
-  cron: "5 * * * * *"
+  cron: "2/10 * * * * *"
   integrasjon:
     joark:
       uri: http://localhost:8091/
@@ -14,5 +14,6 @@ prosess:
       uri: http://localhost:8091/
     api:
       uri: http://localhost:8090/tiltaksgjennomforing-api
+ #     uri: http://localhost:8091/
 
 

--- a/src/main/resources/config/application-dev.yaml
+++ b/src/main/resources/config/application-dev.yaml
@@ -9,9 +9,9 @@ prosess:
   cron: "5 * * * * *"
   integrasjon:
     joark:
-      uri: http://localhost:8091
+      uri: http://localhost:8091/
     sts:
-      uri: http://localhost:8091
+      uri: http://localhost:8091/
     api:
       uri: http://localhost:8090/tiltaksgjennomforing-api
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
@@ -44,17 +44,16 @@ public class JournalpostJobbTest {
     public void kallerIkkeJoarkMedEnAvtaleSomFeilet(){
 
         Avtale okAvtale = TestData.opprettAvtale();
-        UUID idOkAvtale = UUID.randomUUID();
-        okAvtale.setId(idOkAvtale);
+        okAvtale.setId(okAvtale.getId());
 
         Journalpost okJournalpost = new Journalpost();
-        okJournalpost.setEksternReferanseId(idOkAvtale.toString());
+        okJournalpost.setEksternReferanseId(okAvtale.getId().toString());
 
         Avtale feiletAvt = TestData.opprettAvtale();
 
         Map<UUID, String> jorurnalpostIds = new HashMap<>(2);
         final String JOURNALPOST_ID = "1234";
-        jorurnalpostIds.put(idOkAvtale, JOURNALPOST_ID);
+        jorurnalpostIds.put(okAvtale.getId(), JOURNALPOST_ID);
         jorurnalpostIds.put(feiletAvt.getId(), MAPPING_FEIL);
 
         when(stsService.hentToken()).thenReturn("");
@@ -77,9 +76,9 @@ public class JournalpostJobbTest {
         Avtale avtale2 = TestData.opprettAvtale();
 
         Journalpost journalpost1 = new Journalpost();
-        journalpost1.setEksternReferanseId(avtale1.toString());
+        journalpost1.setEksternReferanseId(avtale1.getId().toString());
         Journalpost journalpost2 = new Journalpost();
-        journalpost1.setEksternReferanseId(avtale2.toString());
+        journalpost2.setEksternReferanseId(avtale2.getId().toString());
 
 
         Map<UUID, String> jorurnalpostIds = new HashMap<>(2);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
@@ -14,7 +14,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
+import static no.nav.tag.tiltaksgjennomforingprosess.JournalpostJobb.MAPPING_FEIL;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -36,15 +40,64 @@ public class JournalpostJobbTest {
     @InjectMocks
     private JournalpostJobb journalpostJobb;
 
-    @Test(expected = HttpServerErrorException.class)
-    public void kallerIkkeJoarkHvisfeilet(){
+    @Test
+    public void kallerIkkeJoarkMedEnAvtaleSomFeilet(){
+
+        Avtale okAvtale = TestData.opprettAvtale();
+        UUID idOkAvtale = UUID.randomUUID();
+        okAvtale.setId(idOkAvtale);
+
+        Journalpost okJournalpost = new Journalpost();
+        okJournalpost.setEksternReferanseId(idOkAvtale.toString());
+
+        Avtale feiletAvt = TestData.opprettAvtale();
+
+        Map<UUID, String> jorurnalpostIds = new HashMap<>(2);
+        final String JOURNALPOST_ID = "1234";
+        jorurnalpostIds.put(idOkAvtale, JOURNALPOST_ID);
+        jorurnalpostIds.put(feiletAvt.getId(), MAPPING_FEIL);
+
         when(stsService.hentToken()).thenReturn("");
-        when(tiltaksgjennomfoeringApiService.finnAvtalerTilJournalfoering(anyString())).thenReturn(Arrays.asList(TestData.opprettAvtale()));
-        when(journalpostFactory.konverterTilJournalpost(any(Avtale.class))).thenThrow(HttpServerErrorException.class);
+        when(tiltaksgjennomfoeringApiService.finnAvtalerTilJournalfoering(anyString())).thenReturn(Arrays.asList(okAvtale, feiletAvt));
+
+        when(journalpostFactory.konverterTilJournalpost(okAvtale)).thenReturn(okJournalpost);
+        when(journalpostFactory.konverterTilJournalpost(feiletAvt)).thenThrow(HttpServerErrorException.class);
+
+        when(joarkService.sendJournalpost(anyString(), eq(okJournalpost))).thenReturn(JOURNALPOST_ID);
 
         journalpostJobb.avtalerTilJournalfoering();
-        verify(joarkService, never()).sendJournalpost(anyString(), any(Journalpost.class));
-        verify(tiltaksgjennomfoeringApiService, never()).settAvtalerTilJournalfoert(anyString(), anyMap());
+        verify(joarkService, times(1)).sendJournalpost(anyString(), eq(okJournalpost));
+        verify(tiltaksgjennomfoeringApiService, atLeastOnce()).settAvtalerTilJournalfoert(anyString(), eq(jorurnalpostIds));
     }
 
+    @Test
+    public void kallerMedAlleAvtaler(){
+
+        Avtale avtale1 = TestData.opprettAvtale();
+        Avtale avtale2 = TestData.opprettAvtale();
+
+        Journalpost journalpost1 = new Journalpost();
+        journalpost1.setEksternReferanseId(avtale1.toString());
+        Journalpost journalpost2 = new Journalpost();
+        journalpost1.setEksternReferanseId(avtale2.toString());
+
+
+        Map<UUID, String> jorurnalpostIds = new HashMap<>(2);
+        jorurnalpostIds.put(avtale1.getId(), avtale1.getId().toString());
+        jorurnalpostIds.put(avtale2.getId(), avtale2.getId().toString());
+
+        when(stsService.hentToken()).thenReturn("");
+        when(tiltaksgjennomfoeringApiService.finnAvtalerTilJournalfoering(anyString())).thenReturn(Arrays.asList(avtale1, avtale2));
+
+        when(journalpostFactory.konverterTilJournalpost(avtale1)).thenReturn(journalpost1);
+        when(journalpostFactory.konverterTilJournalpost(avtale2)).thenReturn(journalpost2);
+
+        when(joarkService.sendJournalpost(anyString(), eq(journalpost1))).thenReturn(avtale1.getId().toString());
+        when(joarkService.sendJournalpost(anyString(), eq(journalpost2))).thenReturn(avtale2.getId().toString());
+
+        journalpostJobb.avtalerTilJournalfoering();
+        verify(joarkService, times(1)).sendJournalpost(anyString(), eq(journalpost1));
+        verify(joarkService, times(1)).sendJournalpost(anyString(), eq(journalpost2));
+        verify(tiltaksgjennomfoeringApiService, atLeastOnce()).settAvtalerTilJournalfoert(anyString(), eq(jorurnalpostIds));
+    }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
@@ -1,0 +1,50 @@
+package no.nav.tag.tiltaksgjennomforingprosess;
+
+import no.nav.tag.tiltaksgjennomforingprosess.domene.avtale.Avtale;
+import no.nav.tag.tiltaksgjennomforingprosess.domene.journalpost.Journalpost;
+import no.nav.tag.tiltaksgjennomforingprosess.factory.JournalpostFactory;
+import no.nav.tag.tiltaksgjennomforingprosess.integrasjon.JoarkService;
+import no.nav.tag.tiltaksgjennomforingprosess.integrasjon.StsService;
+import no.nav.tag.tiltaksgjennomforingprosess.integrasjon.TiltaksgjennomfoeringApiService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JournalpostJobbTest {
+
+    @Mock
+    private TiltaksgjennomfoeringApiService tiltaksgjennomfoeringApiService;
+
+    @Mock
+    private JournalpostFactory journalpostFactory;
+
+    @Mock
+    private JoarkService joarkService;
+
+    @Mock
+    private StsService stsService;
+
+    @InjectMocks
+    private JournalpostJobb journalpostJobb;
+
+    @Test(expected = HttpServerErrorException.class)
+    public void kallerIkkeJoarkHvisfeilet(){
+        when(stsService.hentToken()).thenReturn("");
+        when(tiltaksgjennomfoeringApiService.finnAvtalerTilJournalfoering(anyString())).thenReturn(Arrays.asList(TestData.opprettAvtale()));
+        when(journalpostFactory.konverterTilJournalpost(any(Avtale.class))).thenThrow(HttpServerErrorException.class);
+
+        journalpostJobb.avtalerTilJournalfoering();
+        verify(joarkService, never()).sendJournalpost(anyString(), any(Journalpost.class));
+        verify(tiltaksgjennomfoeringApiService, never()).settAvtalerTilJournalfoert(anyString(), anyMap());
+    }
+
+}

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/JournalpostJobbTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.web.client.HttpServerErrorException;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -19,7 +18,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static no.nav.tag.tiltaksgjennomforingprosess.JournalpostJobb.MAPPING_FEIL;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,7 +60,7 @@ public class JournalpostJobbTest {
         when(tiltaksgjennomfoeringApiService.finnAvtalerTilJournalfoering(anyString())).thenReturn(Arrays.asList(okAvtale, feiletAvt));
 
         when(journalpostFactory.konverterTilJournalpost(okAvtale)).thenReturn(okJournalpost);
-        when(journalpostFactory.konverterTilJournalpost(feiletAvt)).thenThrow(HttpServerErrorException.class);
+        when(journalpostFactory.konverterTilJournalpost(feiletAvt)).thenThrow(RuntimeException.class);
 
         when(joarkService.sendJournalpost(anyString(), eq(okJournalpost))).thenReturn(JOURNALPOST_ID);
 
@@ -97,6 +97,6 @@ public class JournalpostJobbTest {
         journalpostJobb.avtalerTilJournalfoering();
         verify(joarkService, times(1)).sendJournalpost(anyString(), eq(journalpost1));
         verify(joarkService, times(1)).sendJournalpost(anyString(), eq(journalpost2));
-        verify(tiltaksgjennomfoeringApiService, atLeastOnce()).settAvtalerTilJournalfoert(anyString(), eq(jorurnalpostIds));
+        verify(tiltaksgjennomfoeringApiService, times(1)).settAvtalerTilJournalfoert(anyString(), eq(jorurnalpostIds));
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/TestData.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/TestData.java
@@ -46,8 +46,8 @@ public class TestData {
         avtale.setVeilederFornavn("Nils");
         avtale.setVeilederEtternavn("Nilsen");
         avtale.setVeilederTlf("22223333");
-        avtale.setOppfolging("Linje-1\nlinje-2 \n linje-3\n \nHer kommer resten i ny linje");
-        avtale.setTilrettelegging("Dette er lang tilrettelegging tekst for test");
+        avtale.setOppfolging("Oppfølging under veis om tildelte oppgaver. Og arbeidstager har en oppfølgingsamtale med kjøpmann eller butikksjef ca hver 4 uke, da om miljø på arbeidsplass, arbeidsoppgaver samt egen helse i tildelte oppgaver.");
+        avtale.setTilrettelegging("Det er avtalt at Lillehans får tid til og gjennomføre og prioritere opplæring knyttet til sertifikatet. Videre vil NAV følge jevnlig opp.");
         avtale.setStartDato(START_DATO);
         avtale.setArbeidstreningLengde(2);
         avtale.setArbeidstreningStillingprosent(50);
@@ -64,15 +64,20 @@ public class TestData {
     public static Oppgave enOppgave() {
         Oppgave oppgave = new Oppgave();
         oppgave.setTittel("OppgaveTittel");
-        oppgave.setBeskrivelse("Kandidaten blir fulgt opp av linje ledere / mentor-er Er plassert på Linje A3   Lindal treindustri Akland");
-        oppgave.setOpplaering("Dette er veldig lang opplæring");
+        oppgave.setBeskrivelse("  nr 1 Vi skal lære hun bestille varer fra leverandører og besøker de slik hun få erfaring på det.\n" +
+                "\n" +
+                "Nr 2 vi øve hun  på typiske arbeidsoppgaver er å betjene kunder og kasseapparatet, å rydde i butikken og i hyller, å rydde på lageret, å sette priser på varer, å ta imot bestillinger og ta imot varer.");
+        oppgave.setOpplaering("Tanken bak rullering av varer og plassering av varer. \n" +
+                "Rutiner rundt fersk og kjølevarer\n" +
+                "Opplæring i kasse og kundebehandling\n" +
+                "Generell butikk rutiner og daglige oppgaver");
         return oppgave;
     }
 
     public static Maal etMaal() {
         Maal maal = new Maal();
         maal.setKategori("Her kommer kategorien");
-        maal.setBeskrivelse("Dette er veldig lang Mål beskrivelse for test,");
+        maal.setBeskrivelse("Målet med arbeidstreningen er og få opplæring i arbeidsoppgaver knyttet til sjåførjobb, lære bedriften og kjenne og får den opplæringen du trenger for og kunne tre inn i stillings funksjonen når du har fått førerkortet. Det foreligger bekreftelse på lovnad om jobb dersom kriteriene er oppfylt i forhold til krav om førerkort.");
         return maal;
     }
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/AvtaleTilPdfTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/AvtaleTilPdfTest.java
@@ -10,7 +10,6 @@ import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.springframework.web.client.HttpServerErrorException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -50,7 +49,7 @@ public class AvtaleTilPdfTest {
         sjekkPdfInnhold(avtale, dokument);
     }
 
-    @Test(expected = HttpServerErrorException.class)
+    @Test(expected = RuntimeException.class)
     public void lagerIkkeAvtalePdf() throws IOException {
         Avtale avtale = TestData.opprettAvtale();
         avtale.setId(null);

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
@@ -23,7 +23,6 @@ public class JournalpostFactoryTest {
     @InjectMocks
     private JournalpostFactory journalpostFactory;
 
-    @Ignore
     @Test
     public void konvertererTilJournalpost() throws Exception {
         Avtale avtale = TestData.opprettAvtale();
@@ -56,7 +55,7 @@ public class JournalpostFactoryTest {
     @Test(expected = HttpServerErrorException.class)
     public void avtaleTilXmlFeiler() throws Exception {
         Avtale avtale = TestData.opprettAvtale();
-        //when(avtaleTilXml.genererXml(avtale)).thenThrow(HttpServerErrorException.class);
+        when(avtaleTilXml.genererXml(avtale)).thenThrow(HttpServerErrorException.class);
         journalpostFactory.konverterTilJournalpost(avtale);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
@@ -22,7 +22,7 @@ public class JournalpostFactoryTest {
     @InjectMocks
     private JournalpostFactory journalpostFactory;
 
-    @Test
+    //@Test
     public void konvertererTilJournalpost() throws Exception {
         Avtale avtale = TestData.opprettAvtale();
 
@@ -52,9 +52,9 @@ public class JournalpostFactoryTest {
     }
 
     @Test(expected = HttpServerErrorException.class)
-    public void feiler() throws Exception {
+    public void avtaleTilXmlFeiler() throws Exception {
         Avtale avtale = TestData.opprettAvtale();
-        when(avtaleTilXml.genererXml(avtale)).thenThrow(HttpServerErrorException.class);
+        //when(avtaleTilXml.genererXml(avtale)).thenThrow(HttpServerErrorException.class);
         journalpostFactory.konverterTilJournalpost(avtale);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
@@ -3,6 +3,7 @@ package no.nav.tag.tiltaksgjennomforingprosess.factory;
 import no.nav.tag.tiltaksgjennomforingprosess.TestData;
 import no.nav.tag.tiltaksgjennomforingprosess.domene.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforingprosess.domene.journalpost.Journalpost;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -22,7 +23,8 @@ public class JournalpostFactoryTest {
     @InjectMocks
     private JournalpostFactory journalpostFactory;
 
-    //@Test
+    @Ignore
+    @Test
     public void konvertererTilJournalpost() throws Exception {
         Avtale avtale = TestData.opprettAvtale();
 

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/factory/JournalpostFactoryTest.java
@@ -3,13 +3,11 @@ package no.nav.tag.tiltaksgjennomforingprosess.factory;
 import no.nav.tag.tiltaksgjennomforingprosess.TestData;
 import no.nav.tag.tiltaksgjennomforingprosess.domene.avtale.Avtale;
 import no.nav.tag.tiltaksgjennomforingprosess.domene.journalpost.Journalpost;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.web.client.HttpServerErrorException;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -52,10 +50,10 @@ public class JournalpostFactoryTest {
         });
     }
 
-    @Test(expected = HttpServerErrorException.class)
+    @Test(expected = RuntimeException.class)
     public void avtaleTilXmlFeiler() throws Exception {
         Avtale avtale = TestData.opprettAvtale();
-        when(avtaleTilXml.genererXml(avtale)).thenThrow(HttpServerErrorException.class);
+        when(avtaleTilXml.genererXml(avtale)).thenThrow(RuntimeException.class);
         journalpostFactory.konverterTilJournalpost(avtale);
     }
 }

--- a/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/JoarkServiceTest.java
+++ b/src/test/java/no/nav/tag/tiltaksgjennomforingprosess/integrasjon/JoarkServiceTest.java
@@ -8,7 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpEntity;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -33,9 +32,8 @@ public class JoarkServiceTest {
     @InjectMocks
     private JoarkService joarkService = new JoarkService(new JournalpostProperties(uri));
 
-    @Test(expected = HttpServerErrorException.class)
+    @Test(expected = RuntimeException.class)
     public void oppretterJournalpost_status_500() {
-
         when(restTemplate.postForObject(eq(expUri), any(HttpEntity.class), any())).thenThrow(RuntimeException.class);
         joarkService.sendJournalpost(TOKEN, new Journalpost());
     }


### PR DESCRIPTION
En feil førte til at en avtale ble journalført uten av den ble oppdatert som journalført i avtale-repoet. 
Fiksen sørger for at avtaler som feiler som følge av mapping o.l. får journalpos-id oppdater med "Feilet" - slik at den ikke blir sendt til joark, eller blir rekjørt. 
Integrasjonsfeil setter ingen verdi på avtalens journalpost-id, dvs denne blir rekjørt. 
