### PR TITLE
Enable prometheus og benytt ingress url

### DIFF
--- a/naiserator.yaml
+++ b/naiserator.yaml
@@ -18,6 +18,8 @@ spec:
   readiness:
     path: /tiltaksgjennomforing-prosess/internal/healthcheck
     initialDelay: 30
+  ingresses:
+    - {{ingress}}
   vault:
     enabled: true
   env:
@@ -25,7 +27,7 @@ spec:
       value: {{spring-profil}}
   webproxy: true
   prometheus:
-    enabled: false
+    enabled: true
     path: /tiltaksgjennomforing-prosess/internal/actuator/prometheus
 
 


### PR DESCRIPTION
Slår på prometheus og setter opp ingress-url slik at det er mulig å nå prometheus og de andre interne url-ene til applikasjonen fra en nettleser.