### PR TITLE
Lagt til fiks

### DIFF
--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/persondata/PersondataService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/persondata/PersondataService.java
@@ -3,6 +3,7 @@ package no.nav.tag.tiltaksgjennomforingprosess.persondata;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -18,6 +19,10 @@ public class PersondataService {
     }
 
     public Map<String, Diskresjonskode> hentDiskresjonskoder(Set<String> fnrSet) {
+        if(fnrSet.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
         if (fnrSet.size() > 1000) {
             throw new IllegalArgumentException("Kan ikke hente diskresjonkode for mer enn 1000 om gangen");
         }

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/persondata/PersondataService.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/persondata/PersondataService.java
@@ -19,7 +19,7 @@ public class PersondataService {
     }
 
     public Map<String, Diskresjonskode> hentDiskresjonskoder(Set<String> fnrSet) {
-        if(fnrSet.isEmpty()) {
+        if (fnrSet.isEmpty()) {
             return Collections.emptyMap();
         }
 

--- a/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/persondata/domene/PdlResponsBolk.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforingprosess/persondata/domene/PdlResponsBolk.java
@@ -9,7 +9,8 @@ public record PdlResponsBolk(Data data) {
     public record Data(List<HentPersonBolk> hentPersonBolk) {}
 
     public Map<String, Optional<Diskresjonskode>> utledDiskresjonskoder(Set<String> fnrSet) {
-        Map<String, Optional<Diskresjonskode>> diskresjonskodeMap = data().hentPersonBolk().stream()
+        List<HentPersonBolk> bolk = Optional.ofNullable(data().hentPersonBolk()).orElse(Collections.emptyList());
+        Map<String, Optional<Diskresjonskode>> diskresjonskodeMap = bolk.stream()
             .filter(HentPersonBolk::isOk)
             .flatMap(person -> person.person().folkeregisteridentifikator().stream().map(a -> Map.entry(
                 a.identifikasjonsnummer(),


### PR DESCRIPTION
Dersom man sender inn en tom liste av fødselsnumre til PDL, vil man få en `null` tilbake!

Derfor bør vi legge inn noen guards mot å kalle PDL unødig.